### PR TITLE
Set up simple RetinaNet training

### DIFF
--- a/projects/Flux/dev.Dockerfile
+++ b/projects/Flux/dev.Dockerfile
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:10.1-cudnn7-devel
 # To use this Dockerfile:
 # 1. `nvidia-docker build -f dev.Dockerfile -t flux_detectron2:v0 ../..`
-# 2. `nvidia-docker run -d -v /home/joan/.aws/:/root/.aws/ -v /home/joan/cvdev:/root/cvdev -p 8889:8888 -p 6007:6006 -p 23:22 --name flux_detectron_joan_gpu0 flux_detectron2:v0`
+# 2. `nvidia-docker run -d -v /home/joan/.aws/:/root/.aws/ -v /home/joan/cvdev:/root/cvdev -p 8889:8888 -p 6007:6006 -p 23:22 --name flux_detectron_joan_gpu0 --ipc=host flux_detectron2:v0`
 
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/projects/Flux/notebooks/Register AFT dataset.ipynb
+++ b/projects/Flux/notebooks/Register AFT dataset.ipynb
@@ -1,0 +1,488 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Register AFT dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook shows how to register the latest version of the American Football Tactical (AFT) dataset to `dectectron2`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get the AFT dataset from `quilt3`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure `quilt3` to look into our server and registry:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:03.006185Z",
+     "start_time": "2019-10-15T14:10:01.682858Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import quilt3\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "# Commented lines only necessary the first time\n",
+    "# quilt3.config('https://quilt3.hudltools.com/')\n",
+    "# quilt3.login() \n",
+    "quilt3.config(default_remote_registry='s3://hudlrd-datasets') "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the AFT dataset from `quilt3`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:04.547288Z",
+     "start_time": "2019-10-15T14:10:03.009894Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "user = 'hudlrd'\n",
+    "package = 'american_football_tactical'\n",
+    "parquet = 'detections_df.parquet'\n",
+    "\n",
+    "pkg = quilt3.Package.install(\n",
+    "    f'{user}/{package}', \n",
+    "    registry=None,\n",
+    "    top_hash=None\n",
+    ")\n",
+    "\n",
+    "pkg[parquet].fetch()\n",
+    "df = pd.read_parquet(parquet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:05.978348Z",
+     "start_time": "2019-10-15T14:10:04.552087Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pkg = quilt3.Package.install(\n",
+    "    f'{user}/{package}', \n",
+    "    registry=None,\n",
+    "    top_hash=None\n",
+    ")\n",
+    "\n",
+    "pkg[parquet].fetch()\n",
+    "df = pd.read_parquet(parquet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:06.064679Z",
+     "start_time": "2019-10-15T14:10:05.981882Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"# examples: \", len(df))\n",
+    "\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clean up the dataframe:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:16.659322Z",
+     "start_time": "2019-10-15T14:10:16.531325Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Remove examples tagged as not match frames\n",
+    "aux_df = df\n",
+    "df = df[df.notMatchFrame == False]\n",
+    "print('# examples removed by notMatchFrame filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Remove examples with null boxes or labels\n",
+    "aux_df = df\n",
+    "df = df[~df.bbxs.isnull()]\n",
+    "df = df[~df.labels.isnull()]\n",
+    "print('# examples removed by isnull filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Remove examples with no boxes or labels\n",
+    "aux_df = df\n",
+    "df = df[df.bbxs.map(lambda d: len(d)) > 0]\n",
+    "df = df[df.labels.map(lambda d: len(d)) > 0]\n",
+    "print('# examples removed by empty box or label list filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Remove invalid bounding boxes where width or height are smaller or equak than \n",
+    "aux_df = df\n",
+    "df = df[df.bbxs.map(lambda bbxs: len(set([True for b in bbxs if b[2] <= 0 or b[3] <= 0]))) == 0]\n",
+    "print('# examples removed by invalid box filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Reset dataframe indices\n",
+    "df = df.reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:19.673027Z",
+     "start_time": "2019-10-15T14:10:19.583475Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('# examples: ', len(df))\n",
+    "\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T13:15:09.455320Z",
+     "start_time": "2019-10-15T13:15:09.440272Z"
+    }
+   },
+   "source": [
+    "At this point is probably a good idea to save the dataset's images to the local machine and update the data frame accordingly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:20.055211Z",
+     "start_time": "2019-10-15T14:10:20.038829Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import requests\n",
+    "from pathlib import Path\n",
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "\n",
+    "\n",
+    "cache = Path('/root/cvdev/aft_images/')\n",
+    "cache.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "\n",
+    "def save_df_images(df):\n",
+    "    def save_df_image(i):\n",
+    "        local_path = cache / f\"{str(i).zfill(4)}.png\"\n",
+    "        if not local_path.exists():\n",
+    "            with open(local_path, 'wb') as f:\n",
+    "                response = requests.get(df.at[i, 'path'], stream=True)\n",
+    "                shutil.copyfileobj(response.raw, f)\n",
+    "        df.at[i, 'path'] = str(local_path.absolute())\n",
+    "\n",
+    "    with ThreadPoolExecutor() as executor:\n",
+    "        list(executor.map(save_df_image, range(len(df))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:20.943298Z",
+     "start_time": "2019-10-15T14:10:20.203823Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "save_df_images(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:21.034900Z",
+     "start_time": "2019-10-15T14:10:20.946572Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Register the AFT dataset to `detectron2`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the dataset's unique labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:21.540818Z",
+     "start_time": "2019-10-15T14:10:21.526437Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "unique_labels = set()\n",
+    "\n",
+    "for labels in df[\"labels\"]:\n",
+    "    if labels is not None:\n",
+    "        unique_labels.update(labels)\n",
+    "\n",
+    "unique_labels = list(unique_labels)\n",
+    "        \n",
+    "print(\"Unique labels:\", unique_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the `get_dicts` function that will return the items in our dataset in the format expected by `detectron2`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:22.279270Z",
+     "start_time": "2019-10-15T14:10:21.544302Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from detectron2.structures import BoxMode\n",
+    "\n",
+    "\n",
+    "def get_dicts(df, partition):\n",
+    "    df = df[df.set_split_random == partition]\n",
+    "    \n",
+    "    records = []\n",
+    "    for i, row in df.iterrows():\n",
+    "        record = {}\n",
+    "        record[\"file_name\"] = row['path']\n",
+    "        record[\"image_id\"] = i\n",
+    "        record[\"height\"] = 2000\n",
+    "        record[\"width\"] = 2666\n",
+    "\n",
+    "        annotations = []\n",
+    "        for bbox, label in zip(row[\"bbxs\"], row[\"labels\"]):\n",
+    "            ann = {}\n",
+    "            bbox = bbox * np.asanyarray([record[\"width\"], record[\"height\"]] * 2)\n",
+    "            ann[\"bbox\"] = bbox.tolist()\n",
+    "            ann[\"bbox_mode\"] = BoxMode.XYWH_ABS\n",
+    "            ann[\"category_id\"] = unique_labels.index(label)\n",
+    "            annotations.append(ann)\n",
+    "\n",
+    "        record[\"annotations\"] =  annotations\n",
+    "        records.append(record)\n",
+    "    \n",
+    "    return records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:23.160684Z",
+     "start_time": "2019-10-15T14:10:22.282530Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"# examples in train:\", len(get_dicts(df, \"train\")))\n",
+    "print(\"# examples in dev:\", len(get_dicts(df, \"dev\")))\n",
+    "print(\"# examples in test:\", len(get_dicts(df, \"test\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tell `detectron2` about the previous function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:23.212071Z",
+     "start_time": "2019-10-15T14:10:23.163115Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from detectron2.data import DatasetCatalog, MetadataCatalog\n",
+    "\n",
+    "\n",
+    "for partition in [\"train\", \"dev\", \"test\"]:\n",
+    "    DatasetCatalog.register(\n",
+    "        f\"AmericanFootballTactical/{partition}\", \n",
+    "        lambda partition = partition: get_dicts(df, partition)\n",
+    "    )\n",
+    "    MetadataCatalog.get(\n",
+    "        f\"AmericanFootballTactical/{partition}\"\n",
+    "    ).set(thing_classes=unique_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make sure the dataset has been correctly registered:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:26.924720Z",
+     "start_time": "2019-10-15T14:10:23.214869Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "DatasetCatalog.get('AmericanFootballTactical/train')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let us plot some of the dataset's data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T14:10:33.641396Z",
+     "start_time": "2019-10-15T14:10:26.928244Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import random\n",
+    "import requests\n",
+    "from PIL import Image, ImageFile\n",
+    "from detectron2.utils.visualizer import Visualizer\n",
+    "\n",
+    "\n",
+    "figsize = (16, 12)\n",
+    "ImageFile.LOAD_TRUNCATED_IMAGES = True\n",
+    "\n",
+    "metadata = MetadataCatalog.get(\"AmericanFootballTactical/train\")\n",
+    "records = get_dicts(df, \"train\")\n",
+    "\n",
+    "for i, r in enumerate(random.sample(records, 5)):\n",
+    "#     img = Image.open(requests.get(r[\"file_name\"], stream=True).raw)\n",
+    "    img = Image.open(r[\"file_name\"])\n",
+    "    img = np.asanyarray(img)\n",
+    "    \n",
+    "    visualizer = Visualizer(img, metadata=metadata, scale=0.5)\n",
+    "    vis = visualizer.draw_dataset_dict(r)\n",
+    "    \n",
+    "    plt.figure(i, figsize=figsize)\n",
+    "    plt.imshow(vis.get_image())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/projects/Flux/notebooks/Train RetinaNet on the AFT dataset.ipynb
+++ b/projects/Flux/notebooks/Train RetinaNet on the AFT dataset.ipynb
@@ -1,0 +1,624 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train RetinaNet on AFT dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook shows how train a RetinaNet model on the American Football Tactical (AFT) dataset using `detectron2`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get the AFT dataset from `quilt3`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure `quilt3` to look into our server and registry:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:39.606562Z",
+     "start_time": "2019-10-15T17:11:38.341351Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import quilt3\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "# Commented lines only necessary the first time\n",
+    "# quilt3.config('https://quilt3.hudltools.com/')\n",
+    "# quilt3.login() \n",
+    "quilt3.config(default_remote_registry='s3://hudlrd-datasets') "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the AFT dataset from `quilt3`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:40.950532Z",
+     "start_time": "2019-10-15T17:11:39.608474Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "user = 'hudlrd'\n",
+    "package = 'american_football_tactical'\n",
+    "parquet = 'detections_df.parquet'\n",
+    "\n",
+    "pkg = quilt3.Package.install(\n",
+    "    f'{user}/{package}', \n",
+    "    registry=None,\n",
+    "    top_hash=None\n",
+    ")\n",
+    "\n",
+    "pkg[parquet].fetch()\n",
+    "df = pd.read_parquet(parquet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:42.314410Z",
+     "start_time": "2019-10-15T17:11:42.247071Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"# examples: \", len(df))\n",
+    "\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clean up the dataframe:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:42.397179Z",
+     "start_time": "2019-10-15T17:11:42.319614Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Remove examples tagged as not match frames\n",
+    "aux_df = df\n",
+    "df = df[df.notMatchFrame == False]\n",
+    "print('# examples removed by notMatchFrame filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Remove examples with null boxes or labels\n",
+    "aux_df = df\n",
+    "df = df[~df.bbxs.isnull()]\n",
+    "df = df[~df.labels.isnull()]\n",
+    "print('# examples removed by isnull filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Remove examples with no boxes or labels\n",
+    "aux_df = df\n",
+    "df = df[df.bbxs.map(lambda d: len(d)) > 0]\n",
+    "df = df[df.labels.map(lambda d: len(d)) > 0]\n",
+    "print('# examples removed by empty box or label list filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Remove invalid bounding boxes where width or height are smaller or equak than \n",
+    "aux_df = df\n",
+    "df = df[df.bbxs.map(lambda bbxs: len(set([True for b in bbxs if b[2] <= 0 or b[3] <= 0]))) == 0]\n",
+    "print('# examples removed by invalid box filtering: ', len(aux_df) - len(df))\n",
+    "\n",
+    "# Reset dataframe indices\n",
+    "df = df.reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:42.450272Z",
+     "start_time": "2019-10-15T17:11:42.398846Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('# examples: ', len(df))\n",
+    "\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T13:15:09.455320Z",
+     "start_time": "2019-10-15T13:15:09.440272Z"
+    }
+   },
+   "source": [
+    "At this point is probably a good idea to save the dataset's images to the local machine and update the data frame accordingly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:42.472631Z",
+     "start_time": "2019-10-15T17:11:42.452508Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import requests\n",
+    "from pathlib import Path\n",
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "\n",
+    "\n",
+    "cache = Path('./aft_images/')\n",
+    "cache.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "\n",
+    "def save_df_images(df):\n",
+    "    def save_df_image(i):\n",
+    "        local_path = cache / f\"{str(i).zfill(4)}.png\"\n",
+    "        if not local_path.exists():\n",
+    "            with open(local_path, 'wb') as f:\n",
+    "                response = requests.get(df.at[i, 'path'], stream=True)\n",
+    "                shutil.copyfileobj(response.raw, f)\n",
+    "        df.at[i, 'path'] = str(local_path.absolute())\n",
+    "\n",
+    "    with ThreadPoolExecutor() as executor:\n",
+    "        list(executor.map(save_df_image, range(len(df))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:43.278857Z",
+     "start_time": "2019-10-15T17:11:42.656775Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "save_df_images(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:43.640037Z",
+     "start_time": "2019-10-15T17:11:43.565392Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Register the AFT dataset to `detectron2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:49.246649Z",
+     "start_time": "2019-10-15T17:11:48.658147Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import detectron2\n",
+    "from detectron2.utils.logger import setup_logger\n",
+    "setup_logger()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the dataset's unique labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:49.324122Z",
+     "start_time": "2019-10-15T17:11:49.307420Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "unique_labels = set()\n",
+    "\n",
+    "for labels in df[\"labels\"]:\n",
+    "    if labels is not None:\n",
+    "        unique_labels.update(labels)\n",
+    "\n",
+    "unique_labels = list(unique_labels)\n",
+    "        \n",
+    "print(\"Unique labels:\", unique_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the `get_dicts` function that will return the items in our dataset in the format expected by `detectron2`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:50.525860Z",
+     "start_time": "2019-10-15T17:11:50.411912Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from detectron2.structures import BoxMode\n",
+    "\n",
+    "\n",
+    "def get_dicts(df, partition):\n",
+    "    df = df[df.set_split_random == partition]\n",
+    "    \n",
+    "    records = []\n",
+    "    for i, row in df.iterrows():\n",
+    "        record = {}\n",
+    "        record[\"file_name\"] = row['path']\n",
+    "        record[\"image_id\"] = i\n",
+    "        record[\"height\"] = 2000\n",
+    "        record[\"width\"] = 2666\n",
+    "\n",
+    "        annotations = []\n",
+    "        for bbox, label in zip(row[\"bbxs\"], row[\"labels\"]):\n",
+    "            ann = {}\n",
+    "            bbox = bbox * np.asanyarray([record[\"width\"], record[\"height\"]] * 2)\n",
+    "            ann[\"bbox\"] = bbox.tolist()\n",
+    "            ann[\"bbox_mode\"] = BoxMode.XYWH_ABS\n",
+    "            ann[\"category_id\"] = unique_labels.index(label)\n",
+    "            annotations.append(ann)\n",
+    "\n",
+    "        record[\"annotations\"] =  annotations\n",
+    "        records.append(record)\n",
+    "    \n",
+    "    return records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:51.619136Z",
+     "start_time": "2019-10-15T17:11:50.730748Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"# examples in train:\", len(get_dicts(df, \"train\")))\n",
+    "print(\"# examples in dev:\", len(get_dicts(df, \"dev\")))\n",
+    "print(\"# examples in test:\", len(get_dicts(df, \"test\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tell `detectron2` about the previous function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:52.484107Z",
+     "start_time": "2019-10-15T17:11:52.444421Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from detectron2.data import DatasetCatalog, MetadataCatalog\n",
+    "\n",
+    "\n",
+    "for partition in [\"train\", \"dev\", \"test\"]:\n",
+    "    DatasetCatalog.register(\n",
+    "        f\"AmericanFootballTactical/{partition}\", \n",
+    "        lambda partition = partition: get_dicts(df, partition)\n",
+    "    )\n",
+    "    MetadataCatalog.get(\n",
+    "        f\"AmericanFootballTactical/{partition}\"\n",
+    "    ).set(thing_classes=unique_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make sure the dataset has been correctly registered:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:53.302203Z",
+     "start_time": "2019-10-15T17:11:53.299102Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# DatasetCatalog.get('AmericanFootballTactical/train')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let us plot some of the dataset's data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:53.676426Z",
+     "start_time": "2019-10-15T17:11:53.671094Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# %matplotlib inline\n",
+    "# import matplotlib.pyplot as plt\n",
+    "\n",
+    "# import random\n",
+    "# import requests\n",
+    "# from PIL import Image, ImageFile\n",
+    "# from detectron2.utils.visualizer import Visualizer\n",
+    "\n",
+    "\n",
+    "# figsize = (16, 12)\n",
+    "# ImageFile.LOAD_TRUNCATED_IMAGES = True\n",
+    "\n",
+    "# metadata = MetadataCatalog.get(\"AmericanFootballTactical/train\")\n",
+    "# records = get_dicts(df, \"train\")\n",
+    "\n",
+    "# for i, r in enumerate(random.sample(records, 5)):\n",
+    "# #     img = Image.open(requests.get(r[\"file_name\"], stream=True).raw)\n",
+    "#     img = Image.open(r[\"file_name\"])\n",
+    "#     img = np.asanyarray(img)\n",
+    "    \n",
+    "#     visualizer = Visualizer(img, metadata=metadata, scale=0.5)\n",
+    "#     vis = visualizer.draw_dataset_dict(r)\n",
+    "    \n",
+    "#     plt.figure(i, figsize=figsize)\n",
+    "#     plt.imshow(vis.get_image())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train RetinaNet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:54.613350Z",
+     "start_time": "2019-10-15T17:11:54.355567Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from detectron2.engine import DefaultTrainer\n",
+    "from detectron2.config import get_cfg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:54.625127Z",
+     "start_time": "2019-10-15T17:11:54.617148Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cfg = get_cfg()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:55.010981Z",
+     "start_time": "2019-10-15T17:11:55.004299Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "print(cfg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:11:56.518872Z",
+     "start_time": "2019-10-15T17:11:56.481450Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cfg.merge_from_file(\"../../../configs/COCO-Detection/retinanet_R_50_FPN_3x.yaml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:12:03.297174Z",
+     "start_time": "2019-10-15T17:12:03.290400Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cfg.DATASETS.TRAIN = (\"AmericanFootballTactical/train\",)\n",
+    "cfg.DATASETS.TEST = (\"AmericanFootballTactical/dev\",)\n",
+    "cfg.SOLVER.IMS_PER_BATCH = 6\n",
+    "cfg.SOLVER.MAX_ITER = 10000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:12:04.485296Z",
+     "start_time": "2019-10-15T17:12:04.479938Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "\n",
+    "os.makedirs(cfg.OUTPUT_DIR, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:12:12.831301Z",
+     "start_time": "2019-10-15T17:12:05.318375Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "trainer = DefaultTrainer(cfg) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:12:40.458364Z",
+     "start_time": "2019-10-15T17:12:34.545997Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "trainer.resume_or_load(resume=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-15T17:12:56.430620Z",
+     "start_time": "2019-10-15T17:12:55.299988Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "trainer.train()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/projects/Flux/notebooks/Train RetinaNet on the AFT dataset.ipynb
+++ b/projects/Flux/notebooks/Train RetinaNet on the AFT dataset.ipynb
@@ -33,8 +33,7 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:39.606562Z",
-     "start_time": "2019-10-15T17:11:38.341351Z"
+     "start_time": "2019-10-16T09:49:27.898Z"
     }
    },
    "outputs": [],
@@ -61,8 +60,7 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:40.950532Z",
-     "start_time": "2019-10-15T17:11:39.608474Z"
+     "start_time": "2019-10-16T09:49:28.189Z"
     }
    },
    "outputs": [],
@@ -86,8 +84,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:42.314410Z",
-     "start_time": "2019-10-15T17:11:42.247071Z"
+     "end_time": "2019-10-16T09:49:32.600528Z",
+     "start_time": "2019-10-16T09:49:32.514614Z"
     }
    },
    "outputs": [],
@@ -109,8 +107,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:42.397179Z",
-     "start_time": "2019-10-15T17:11:42.319614Z"
+     "end_time": "2019-10-16T09:49:32.724266Z",
+     "start_time": "2019-10-16T09:49:32.603406Z"
     }
    },
    "outputs": [],
@@ -146,8 +144,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:42.450272Z",
-     "start_time": "2019-10-15T17:11:42.398846Z"
+     "end_time": "2019-10-16T09:49:32.781708Z",
+     "start_time": "2019-10-16T09:49:32.726576Z"
     }
    },
    "outputs": [],
@@ -174,8 +172,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:42.472631Z",
-     "start_time": "2019-10-15T17:11:42.452508Z"
+     "end_time": "2019-10-16T09:49:32.797156Z",
+     "start_time": "2019-10-16T09:49:32.783575Z"
     }
    },
    "outputs": [],
@@ -208,8 +206,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:43.278857Z",
-     "start_time": "2019-10-15T17:11:42.656775Z"
+     "end_time": "2019-10-16T09:49:33.345341Z",
+     "start_time": "2019-10-16T09:49:32.798671Z"
     }
    },
    "outputs": [],
@@ -222,8 +220,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:43.640037Z",
-     "start_time": "2019-10-15T17:11:43.565392Z"
+     "end_time": "2019-10-16T09:49:33.416186Z",
+     "start_time": "2019-10-16T09:49:33.347928Z"
     }
    },
    "outputs": [],
@@ -243,8 +241,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:49.246649Z",
-     "start_time": "2019-10-15T17:11:48.658147Z"
+     "end_time": "2019-10-16T09:49:34.116986Z",
+     "start_time": "2019-10-16T09:49:33.418065Z"
     }
    },
    "outputs": [],
@@ -266,8 +264,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:49.324122Z",
-     "start_time": "2019-10-15T17:11:49.307420Z"
+     "end_time": "2019-10-16T09:49:34.131999Z",
+     "start_time": "2019-10-16T09:49:34.119555Z"
     }
    },
    "outputs": [],
@@ -295,8 +293,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:50.525860Z",
-     "start_time": "2019-10-15T17:11:50.411912Z"
+     "end_time": "2019-10-16T09:49:34.244066Z",
+     "start_time": "2019-10-16T09:49:34.135342Z"
     }
    },
    "outputs": [],
@@ -336,8 +334,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:51.619136Z",
-     "start_time": "2019-10-15T17:11:50.730748Z"
+     "end_time": "2019-10-16T09:49:35.114075Z",
+     "start_time": "2019-10-16T09:49:34.246527Z"
     }
    },
    "outputs": [],
@@ -359,8 +357,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:52.484107Z",
-     "start_time": "2019-10-15T17:11:52.444421Z"
+     "end_time": "2019-10-16T09:49:35.140605Z",
+     "start_time": "2019-10-16T09:49:35.116315Z"
     }
    },
    "outputs": [],
@@ -390,9 +388,10 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:53.302203Z",
-     "start_time": "2019-10-15T17:11:53.299102Z"
-    }
+     "end_time": "2019-10-16T09:49:35.147851Z",
+     "start_time": "2019-10-16T09:49:35.144980Z"
+    },
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -411,8 +410,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:53.676426Z",
-     "start_time": "2019-10-15T17:11:53.671094Z"
+     "end_time": "2019-10-16T09:49:35.169730Z",
+     "start_time": "2019-10-16T09:49:35.150461Z"
     },
     "scrolled": false
    },
@@ -423,12 +422,11 @@
     "\n",
     "# import random\n",
     "# import requests\n",
-    "# from PIL import Image, ImageFile\n",
+    "# from PIL import Image\n",
     "# from detectron2.utils.visualizer import Visualizer\n",
     "\n",
     "\n",
     "# figsize = (16, 12)\n",
-    "# ImageFile.LOAD_TRUNCATED_IMAGES = True\n",
     "\n",
     "# metadata = MetadataCatalog.get(\"AmericanFootballTactical/train\")\n",
     "# records = get_dicts(df, \"train\")\n",
@@ -457,8 +455,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:54.613350Z",
-     "start_time": "2019-10-15T17:11:54.355567Z"
+     "end_time": "2019-10-16T09:49:35.465776Z",
+     "start_time": "2019-10-16T09:49:35.171952Z"
     }
    },
    "outputs": [],
@@ -472,8 +470,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:54.625127Z",
-     "start_time": "2019-10-15T17:11:54.617148Z"
+     "end_time": "2019-10-16T09:49:35.717723Z",
+     "start_time": "2019-10-16T09:49:35.709957Z"
     }
    },
    "outputs": [],
@@ -486,8 +484,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:55.010981Z",
-     "start_time": "2019-10-15T17:11:55.004299Z"
+     "end_time": "2019-10-16T09:49:36.274911Z",
+     "start_time": "2019-10-16T09:49:36.267645Z"
     },
     "scrolled": false
    },
@@ -501,8 +499,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:11:56.518872Z",
-     "start_time": "2019-10-15T17:11:56.481450Z"
+     "end_time": "2019-10-16T09:49:37.016794Z",
+     "start_time": "2019-10-16T09:49:36.976040Z"
     }
    },
    "outputs": [],
@@ -515,14 +513,14 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:12:03.297174Z",
-     "start_time": "2019-10-15T17:12:03.290400Z"
+     "end_time": "2019-10-16T13:53:59.939867Z",
+     "start_time": "2019-10-16T13:53:59.932128Z"
     }
    },
    "outputs": [],
    "source": [
     "cfg.DATASETS.TRAIN = (\"AmericanFootballTactical/train\",)\n",
-    "cfg.DATASETS.TEST = (\"AmericanFootballTactical/dev\",)\n",
+    "cfg.DATASETS.TEST = ()\n",
     "cfg.SOLVER.IMS_PER_BATCH = 6\n",
     "cfg.SOLVER.MAX_ITER = 10000"
    ]
@@ -532,8 +530,22 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:12:04.485296Z",
-     "start_time": "2019-10-15T17:12:04.479938Z"
+     "end_time": "2019-10-16T13:54:01.584525Z",
+     "start_time": "2019-10-16T13:54:01.579218Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cfg.SOLVER.BASE_LR = 3e-3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-16T13:54:01.947827Z",
+     "start_time": "2019-10-16T13:54:01.942195Z"
     }
    },
    "outputs": [],
@@ -549,8 +561,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:12:12.831301Z",
-     "start_time": "2019-10-15T17:12:05.318375Z"
+     "end_time": "2019-10-16T13:54:04.972185Z",
+     "start_time": "2019-10-16T13:54:02.931280Z"
     }
    },
    "outputs": [],
@@ -563,13 +575,13 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:12:40.458364Z",
-     "start_time": "2019-10-15T17:12:34.545997Z"
+     "end_time": "2019-10-16T13:54:09.602909Z",
+     "start_time": "2019-10-16T13:54:09.163308Z"
     }
    },
    "outputs": [],
    "source": [
-    "trainer.resume_or_load(resume=False)"
+    "trainer.resume_or_load(resume=True)"
    ]
   },
   {
@@ -577,13 +589,81 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2019-10-15T17:12:56.430620Z",
-     "start_time": "2019-10-15T17:12:55.299988Z"
+     "start_time": "2019-10-16T13:54:11.596Z"
     }
    },
    "outputs": [],
    "source": [
     "trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluate RetinaNet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-16T13:47:49.012370Z",
+     "start_time": "2019-10-16T13:47:47.976388Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from detectron2.engine import DefaultPredictor\n",
+    "\n",
+    "\n",
+    "cfg.MODEL.WEIGHTS = str(Path(cfg.OUTPUT_DIR) / \"model_final.pth\")\n",
+    "cfg.DATASETS.TEST = (\"AmericanFootballTactical/dev\",\"AmericanFootballTactical/test\")\n",
+    "\n",
+    "predictor = DefaultPredictor(cfg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-16T13:50:57.013629Z",
+     "start_time": "2019-10-16T13:50:51.208337Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import random\n",
+    "from PIL import Image\n",
+    "from detectron2.utils.visualizer import Visualizer\n",
+    "\n",
+    "\n",
+    "figsize = (16, 12)\n",
+    "\n",
+    "records = get_dicts(df, partition=\"dev\")\n",
+    "metadata = MetadataCatalog.get(\"AmericanFootballTactical/dev\")\n",
+    "\n",
+    "for i, r in enumerate(random.sample(records, 3)):\n",
+    "    img = np.asanyarray(Image.open(r[\"file_name\"]))\n",
+    "    \n",
+    "    outputs = predictor(img)\n",
+    "    \n",
+    "    v = Visualizer(\n",
+    "        img,\n",
+    "        metadata=metadata,\n",
+    "        scale=0.5,\n",
+    "    )\n",
+    "    v = v.draw_instance_predictions(outputs[\"instances\"].to(\"cpu\"))\n",
+    "    \n",
+    "    plt.figure(i, figsize=figsize)\n",
+    "    plt.imshow(v.get_image())"
    ]
   }
  ],
@@ -603,7 +683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.0"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Builds upon #1 to create a new notebook that trains the default RetinaNet model in `detectron2` on the AFT (American Football Tactical) dataset.